### PR TITLE
Issues 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .vscode
+.python-version
+test.png
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
-import ocr.py
-import search.py
+import ocr
+import search
 
 
 

--- a/ocr.py
+++ b/ocr.py
@@ -22,26 +22,25 @@ def tesseract_init():
     return tools[0]
 
 
-def get_window_position():
+def get_window_image():
     handle = win32gui.FindWindow(None, st.TARGET_NAME)
     rect = win32gui.GetWindowRect(handle)
-    return rect
+    ImageGrab.grab(rect)
+    return image
 
 
 #TODO get_event_title_image, get_event_choices_image の中でenhanceまでやる？
 #TODO get_event_choices_image の呼び出し回数に応じて上に移動するか判断
 
-def get_event_title_image(rect):
-    width = rect[2]-rect[0]
-    height = rect[3]-rect[1]
+def crop_event_title_image(img):
+    width,height = img.size
 
-    left = rect[0] + width*0.16
-    right = rect[2] - width*0.35
-    top = rect[1] + height*0.21
-    bottom = rect[3] - height*0.76
+    left = width*0.16
+    right = width*0.7
+    top = height*0.21
+    bottom = height*0.24
 
-    new_rect = [left,top,right,bottom]
-    return ImageGrab.grab(new_rect)
+    return img.crop((left,top,right,bottom))
 
 
 def enhance_image(img):
@@ -83,10 +82,10 @@ def get_event():
 
     img = None
     if not st.DEBUG_IMAGE_PATH:
-        rect = get_window_position()
-        img = get_event_title_image(rect)
+        img = get_window_image()
     else:
         img = Image.open(st.DEBUG_IMAGE_PATH)
+    img = crop_event_title_image(img)
     img = enhance_image(img)
 
     result = OCR(tesseract, img)

--- a/ocr.py
+++ b/ocr.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import json
 import os
 from collections import OrderedDict

--- a/ocr.py
+++ b/ocr.py
@@ -2,16 +2,15 @@ import json
 import os
 from collections import OrderedDict
 
+import settings as st
+
 import numpy as np
 import pyocr
 import pyocr.builders
 import pyperclip
-#import win32gui
+if not st.DEBUG_IMAGE_PATH:
+    import win32gui
 from PIL import Image, ImageEnhance, ImageGrab, ImageOps
-
-import settings as st
-
-
 
 def tesseract_init():
     # 1.インストール済みのTesseractのパスを通す

--- a/ocr.py
+++ b/ocr.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import json
 import os
 from collections import OrderedDict
@@ -6,10 +8,10 @@ import numpy as np
 import pyocr
 import pyocr.builders
 import pyperclip
-import win32gui
-from PIL import ImageEnhance, ImageGrab, ImageOps
+#import win32gui
+from PIL import Image, ImageEnhance, ImageGrab, ImageOps
 
-import settings.py as st
+import settings as st
 
 
 
@@ -68,7 +70,6 @@ def is_event_display():
 
 def get_event():
     tesseract = tesseract_init()
-    rect = get_window_position()
 
     #TODO 選択肢が出ているかどうかを判定するループ
 
@@ -83,7 +84,12 @@ def get_event():
                 break
     """
 
-    img = get_event_title_image(rect)
+    img = None
+    if not st.DEBUG_IMAGE_PATH:
+        rect = get_window_position()
+        img = get_event_title_image(rect)
+    else:
+        img = Image.open(st.DEBUG_IMAGE_PATH)
     img = enhance_image(img)
 
     result = OCR(tesseract, img)

--- a/settings.py
+++ b/settings.py
@@ -1,2 +1,3 @@
 TARGET_NAME = 'umamusume'
-TESSERACT_PATH = "C:\\Program Files\\Tesseract-OCR"
+TESSERACT_PATH = "/usr/local/Cellar/tesseract/"
+DEBUG_IMAGE_PATH = "test.png"


### PR DESCRIPTION
#11 
settings.py にDEBUG_IMAGE_PATHを追加
切り取り範囲の計算をしてパーツごとにImageGrabする設計になっていた部分を最初のwindow位置を調べる関数に結合して一度のImageGrabですむよう変更、（ベースになるイメージを弄る方式になるので保存されているテストイメージからも同じ処理を通してテストできるようになる）